### PR TITLE
Create swap two gfg potd

### DIFF
--- a/swap two gfg potd
+++ b/swap two gfg potd
@@ -1,0 +1,56 @@
+//{ Driver Code Starts
+
+#include <bits/stdc++.h>
+using namespace std;
+
+
+// } Driver Code Ends
+class Solution {
+  public:
+    bool checkSorted(vector<int> &arr) {
+        // code here.
+          int cnt = 0;
+         for(int i = 0; i<arr.size(); i++){
+            while(arr[i] != i+1){
+                swap(arr[i],arr[arr[i]-1]);
+                cnt++;
+                
+                if(cnt>2){
+                    return false;
+                }
+            }
+        }
+        if(cnt == 0 || cnt == 2){
+        return true;
+        }
+        else
+            return false;
+    }
+};
+
+//{ Driver Code Starts.
+
+int main() {
+
+    int t;
+    cin >> t;
+    cin.ignore();
+    while (t--) {
+        string input;
+        getline(cin, input);
+        stringstream ss(input);
+        int num;
+        vector<int> arr;
+        while (ss >> num)
+            arr.push_back(num);
+
+        Solution ob;
+        bool ans = ob.checkSorted(arr);
+        if (ans)
+            cout << "true" << endl;
+        else
+            cout << "false" << endl;
+    }
+}
+
+// } Driver Code Ends


### PR DESCRIPTION
Given a permutation of some of the first natural numbers in an array arr[], determine if the array can be sorted in exactly two swaps. A swap can involve the same pair of indices twice.

Return true if it is possible to sort the array with exactly two swaps, otherwise return false.

Examples:

Input: arr = [4, 3, 2, 1]
Output: true
Explanation: First, swap arr[0] and arr[3]. The array becomes [1, 3, 2, 4]. Then, swap arr[1] and arr[2]. The array becomes [1, 2, 3, 4], which is sorted.